### PR TITLE
tuneup + test fix up (incomplete)

### DIFF
--- a/datalad_container/containers_add.py
+++ b/datalad_container/containers_add.py
@@ -353,11 +353,14 @@ class ContainersAdd(Interface):
                              "Available placeholders: %s",
                              repr(xi), exc, ', '.join(extra_input_placeholders)))
                 return
+
         # actually setting --extra-input config
-        if ds.config.get("{}.extra-input".format(cfgbasevar)) is not None:
-            ds.config.unset("{}.extra-input".format(cfgbasevar))
+        cfgextravar = "{}.extra-input".format(cfgbasevar)
+        if ds.config.get(cfgextravar) is not None:
+            ds.config.unset(cfgextravar)
         for xi in (extra_input or []):
-            ds.config.add("{}.extra-input".format(cfgbasevar), xi)
+            ds.config.add(cfgextravar, xi)
+
         # store changes
         to_save.append(op.join(".datalad", "config"))
         for r in ds.save(


### PR DESCRIPTION
ref: https://github.com/datalad/datalad-container/pull/190

see 2nd commit msg for more info and question on what we actually want it to be there ;) overall "fix" was that there was confusion in the test code between `path` (just some temporary path where to create dataset) and `local_file` which in original test was just to keep **single** local file for container to craft url to it.  Here in the test it seems you wanted a "richer" tree of files, so I just got rid of notion of having URL for image and just overlayed that structure (within `sub` subdataset).

feel free to ignore/drop 1st commit

